### PR TITLE
feat: add configurable RPC port support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ First [install foundry](https://getfoundry.sh/) then run:
 
 If all goes well, your RPC will be available on the standard `http://127.0.0.1:8545` endpoint.
 
+To use a custom port (e.g., if 8545 is already in use):
+
+    PORT=8546 ./devland.sh
+
+You can also deploy scenarios to a different RPC endpoint directly:
+
+    RPC_URL=http://127.0.0.1:8546 ./deploy-scenario.sh EulerSwapBasic
+
 ### Private keys
 
 The default is just to use the standard anvil mnemonic. For example this is user 0:

--- a/deploy-scenario.sh
+++ b/deploy-scenario.sh
@@ -7,7 +7,7 @@ SCENARIO=$1
 rm -rf dev-ctx/
 mkdir -p dev-ctx/{addresses,labels,priceapi}/31337
 
-forge script --rpc-url http://127.0.0.1:8545 "script/scenarios/$SCENARIO.s.sol" --broadcast --code-size-limit 100000
+forge script --rpc-url ${RPC_URL:-http://127.0.0.1:8545} "script/scenarios/$SCENARIO.s.sol" --broadcast --code-size-limit 100000
 cast rpc evm_increaseTime 86400
 cast rpc evm_mine
 

--- a/devland.sh
+++ b/devland.sh
@@ -12,11 +12,12 @@ function cleanup {
 trap cleanup EXIT
 
 
-anvil --code-size-limit 100000 &
+PORT=${PORT:-8545}
+anvil --port $PORT --code-size-limit 100000 &
 sleep 1
 
 
-bash ./deploy-scenario.sh "$SCENARIO"
+RPC_URL=http://127.0.0.1:$PORT bash ./deploy-scenario.sh "$SCENARIO"
 
 
 echo -------------------------------


### PR DESCRIPTION
## Summary
- Added support for custom RPC ports to avoid conflicts when default port 8545 is in use
- Made both `devland.sh` and `deploy-scenario.sh` configurable via environment variables

## Changes
- `devland.sh` now accepts `PORT` environment variable (defaults to 8545)
- `deploy-scenario.sh` now accepts `RPC_URL` environment variable (defaults to http://127.0.0.1:8545)
- Updated README with usage examples for both variables

## Test plan
- [x] Tested with default port: `./devland.sh`
- [x] Tested with custom port: `PORT=8546 ./devland.sh`
- [x] Tested direct RPC URL: `RPC_URL=http://127.0.0.1:8546 ./deploy-scenario.sh EulerSwapBasic`

🤖 Generated with [Claude Code](https://claude.ai/code)